### PR TITLE
Remove temporary files and allow new carrierwave version

### DIFF
--- a/carrierwave-webp.gemspec
+++ b/carrierwave-webp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'webp-ffi', '~> 0.2.0'
-  spec.add_dependency 'carrierwave', '~> 1.1'
+  spec.add_dependency 'carrierwave', '>= 0.8'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/carrierwave-webp.gemspec
+++ b/carrierwave-webp.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Max Riveiro']
   spec.email         = ['kavu13@gmail.com']
   spec.description   = %q{CarrierWave module for processing your uploads into WebP format}
-  spec.summary       = %q{CarrierWave module for processing   your uploads into WebP format}
+  spec.summary       = %q{CarrierWave module for processing your uploads into WebP format}
   spec.homepage      = 'https://github.com/kavu/carrierwave-webp'
   spec.license       = 'MIT'
 

--- a/carrierwave-webp.gemspec
+++ b/carrierwave-webp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'webp-ffi', '~> 0.2.0'
-  spec.add_dependency 'carrierwave', '~> 0.8'
+  spec.add_dependency 'carrierwave', '~> 1.1'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/carrierwave-webp.gemspec
+++ b/carrierwave-webp.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Max Riveiro']
   spec.email         = ['kavu13@gmail.com']
   spec.description   = %q{CarrierWave module for processing your uploads into WebP format}
-  spec.summary       = %q{CarrierWave module for processing your uploads into WebP format}
+  spec.summary       = %q{CarrierWave module for processing   your uploads into WebP format}
   spec.homepage      = 'https://github.com/kavu/carrierwave-webp'
   spec.license       = 'MIT'
 

--- a/lib/carrierwave/webp/converter.rb
+++ b/lib/carrierwave/webp/converter.rb
@@ -23,6 +23,8 @@ module CarrierWave
             content_type: 'image/webp'
           })
 
+          FileUtils.rm(webp_path) rescue nil
+
           instance_variable_set('@filename', old_filename)
 
           img


### PR DESCRIPTION
Thanks a lot for the gem! I was using it and the temporary files were building up, so I just added this quick fix to remove the processed temporary webp files after they have been submitted, I hope it helps...